### PR TITLE
Add a simple CI to run the bazel build.

### DIFF
--- a/.github/workflows/github-actions-bazel-build.yml
+++ b/.github/workflows/github-actions-bazel-build.yml
@@ -1,0 +1,39 @@
+name: bazel-build
+
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
+
+jobs:
+  Test:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Create Cache Timestamp
+        id: cache_timestamp
+        uses: nanzm/get-time-action@v2.0
+        with:
+          format: 'YYYY-MM-DD-HH-mm-ss'
+
+      - name: Mount bazel cache
+        uses: actions/cache@v4
+        with:
+          path: "~/.cache/bazel"
+          key: bazelcache_${{ steps.cache_timestamp.outputs.time }}
+          restore-keys: bazelcache_
+
+      - name: Build
+        run: |
+          # There are no cc_test()s yet, so just build for now.
+          # For now, just run, but don't fail the whole CI, as bazel build is
+          # experimental at this stage.
+          bazel build --noshow_progress --keep_going ... | /bin/true


### PR DESCRIPTION
This is an experiment. I've wrapped bazel into a `| /bin/true` so that even if it fails the whole CI is not failing, as this is still experimental.